### PR TITLE
only return the first line of the pass entry

### DIFF
--- a/lookup_plugins/pass.py
+++ b/lookup_plugins/pass.py
@@ -103,7 +103,7 @@ def get_password(path):
     p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
     if p.returncode == 0:
-        return stdout.rstrip()
+        return stdout.splitlines()[0]
     raise Exception(stderr)
 
 def generate_password(path, length, symbols, force=False):


### PR DESCRIPTION
Currently the plugin will return the entire pass entry, which seems
unlikely to be the desired behaviour for users with multiline entries.

For users who only store the password in their entries, this change will
have no effect.

For users who store metadata within the entries, [as suggested on the
password store homepage][0], this change will cause the plugin to only
return the first line, which is where pass itself always expects the
password to be (ie, when copying with -c or generating with -i).

Before this change, if the plugin had been used with the example entry
on the password store homagepage, it would return a multiline string:

    'Yw|ZSNH!}z"6{ym9pI\nURL: *.amazon.com/*\nUsername: AmazonianChicken@example.com\nSecret Question 1: What is your childhood best friend\'s most bizarre superhero fantasy? Oh god, Amazon, it\'s too awful to say...\nPhone Support PIN #: 84719'

After this change, the same entry will result in only the first line
being returned:

    'Yw|ZSNH!}z"6{ym9pI'

Using splitlines() will remove the newline characters from the returned
value. However, unlike the previous use of rstrip(), it does not strip
trailing whitespace at the end of the line. This matches pass's own
behaviour, which tries to avoid making assumptions about the user's
entries (except that the password is on the first line!).

[0]: https://www.passwordstore.org/#organization