### PR TITLE
convert password from bytes to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ You can use parameters to control how `pass generate` will be called.
 
 * **`length`:** length of the generated password (default: `32`).
 * **`symbols`:** include symbols in the generated password (default: `False`).
+* **`regenerate`:** force the generation of a new password (default: `False`).
 
 ### Example
 
 ```yaml
-password: "{{ lookup('pass', 'path/to/your/password length=16 symbols=True') }}"
+password: "{{ lookup('pass', 'path/to/your/password length=16 symbols=True regenerate=True') }}"
 
 ```
 

--- a/lookup_plugins/pass.py
+++ b/lookup_plugins/pass.py
@@ -103,7 +103,7 @@ def get_password(path):
     p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
     if p.returncode == 0:
-        return stdout.rstrip()
+        return stdout.splitlines()[0]
     raise Exception(stderr)
 
 def generate_password(path, length, symbols, force=False):

--- a/lookup_plugins/pass.py
+++ b/lookup_plugins/pass.py
@@ -103,7 +103,7 @@ def get_password(path):
     p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
     if p.returncode == 0:
-        return stdout.splitlines()[0]
+        return stdout.splitlines()[0].decode('utf-8')
     raise Exception(stderr)
 
 def generate_password(path, length, symbols, force=False):


### PR DESCRIPTION
When run on Python 3 (the default in Ansible >= 2.5), the password
output will be bytes. Ansible needs a string. Decoding the output bytes
as unicode fixes this.

On Python 2 this will just convert the string to unicode, which
shouldn't have any effect.